### PR TITLE
Update for RN 0.57

### DIFF
--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -119,7 +119,7 @@ export default class CameraScreenBase extends Component {
         <Image
           style={{ flex: 1, justifyContent: 'center' }}
           source={this.state.flashData.image}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
         />
       </TouchableOpacity>
   }
@@ -130,7 +130,7 @@ export default class CameraScreenBase extends Component {
         <Image
           style={{ flex: 1, justifyContent: 'center' }}
           source={this.props.cameraFlipImage}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode="contain"
         />
       </TouchableOpacity>
   }


### PR DESCRIPTION
`Image.resizeMode` is no longer available.
This updates those references to the string values.

See:
* https://github.com/facebook/react-native/issues/20177
* https://facebook.github.io/react-native/docs/image.html